### PR TITLE
[Temporary] make the bot run tf2 when need to craft only

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -141,7 +141,7 @@ export = class MyHandler extends Handler {
                 ')'
         );
 
-        this.bot.client.gamesPlayed(['tf2-automatic', 440]);
+        this.bot.client.gamesPlayed('tf2-automatic');
         this.bot.client.setPersona(SteamUser.EPersonaState.Online);
 
         // Smelt / combine metal if needed
@@ -180,7 +180,7 @@ export = class MyHandler extends Handler {
     onLoggedOn(): void {
         if (this.bot.isReady()) {
             this.bot.client.setPersona(SteamUser.EPersonaState.Online);
-            this.bot.client.gamesPlayed(['tf2-automatic', 440]);
+            this.bot.client.gamesPlayed('tf2-automatic');
         }
     }
 
@@ -1303,6 +1303,6 @@ export = class MyHandler extends Handler {
 
     onTF2QueueCompleted(): void {
         log.debug('Queue finished');
-        this.bot.client.gamesPlayed(['tf2-automatic', 440]);
+        this.bot.client.gamesPlayed('tf2-automatic');
     }
 };


### PR DESCRIPTION
Due to the news about TF2 source code leak, I revert the update that makes the bot always run tf2 in background.