### PR TITLE
add pure stock to trade summary (chat and discord)

### DIFF
--- a/src/template.discordWebhookAcceptedTrade.json
+++ b/src/template.discordWebhookAcceptedTrade.json
@@ -15,7 +15,7 @@
                 "url": ""
             },
             "title": "",
-            "description": "A trade with %partnerName% has been marked as accepted.\n__Summary__:\n%tradeSummary%\nKey rate: %keyPrice% ref",
+            "description": "A trade with %partnerName% has been marked as accepted.\n__Summary__:\n%tradeSummary%\nKey rate: %keyPrice% ref | Pure stock: %pureStock%",
             "color": "15794337"
         }
     ]


### PR DESCRIPTION
You'll need to add `%pureStock%` into the **description** variable on your `discordWebhookAcceptedTrade.json` to activate it. See image below:
[pureStock](https://user-images.githubusercontent.com/47635037/81786026-b3298400-9531-11ea-9c38-ec991a736ae1.PNG)
