### PR TITLE
src: fixes/changes/update

### DIFF
--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -692,10 +692,11 @@ export = class Commands {
 
         this.bot.sendMessage(
             steamID,
-            pluralize(name, Math.abs(amount), true) +
+            '✅ ' +
+                pluralize(name, Math.abs(amount), true) +
                 ' has been ' +
                 (amount >= 0 ? 'added to' : 'removed from') +
-                ' your cart. 🛒'
+                ' your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
         );
     }
 
@@ -759,15 +760,16 @@ export = class Commands {
                     pluralize(name, amount, true) +
                     '. ' +
                     (amount > 1 ? 'They have' : 'It has') +
-                    ' been added to your cart 🛒.'
+                    ' been added to your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         } else {
             this.bot.sendMessage(
                 steamID,
-                pluralize(name, Math.abs(amount), true) +
+                '✅ ' +
+                    pluralize(name, Math.abs(amount), true) +
                     ' has been ' +
                     (amount >= 0 ? 'added to' : 'removed from') +
-                    ' your cart. 🛒'
+                    ' your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         }
 
@@ -834,14 +836,14 @@ export = class Commands {
                     pluralize(name, amount, true) +
                     '. ' +
                     (amount > 1 ? 'They have' : 'It has') +
-                    ' been added to your cart.'
+                    ' been added to your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         } else {
             this.bot.sendMessage(
                 steamID,
                 '✅ ' +
                     pluralize(name, Math.abs(amount), true) +
-                    ' has been added to your cart. Type !cart to view your cart summary or !checkout to checkout. 🛒'
+                    ' has been added to your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         }
 
@@ -905,14 +907,14 @@ export = class Commands {
                     pluralize(name, amount, true) +
                     '. ' +
                     (amount > 1 ? 'They have' : 'It has') +
-                    ' been added to your cart. 🛒'
+                    ' been added to your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         } else {
             this.bot.sendMessage(
                 steamID,
                 '✅ ' +
                     pluralize(name, Math.abs(amount), true) +
-                    ' has been added to your cart. Type !cart to view your cart summary or !checkout to checkout. 🛒'
+                    ' has been added to your cart. Type "!cart" to view your cart summary or "!checkout" to checkout. 🛒'
             );
         }
 
@@ -1861,7 +1863,14 @@ export = class Commands {
                 steamID,
                 '❌ I could not find any items in my pricelist that contains "' +
                     name +
-                    '", I might not be trading the item you are looking for.'
+                    '", I might not be trading the item you are looking for, or try:' +
+                    '\n• remove "The"' +
+                    '\n• some Taunt needs "The" like "Taunt: The High Five!", and some are not.' +
+                    '\n• check for dash (-) like "All-Father" or "Mini-Engy"' +
+                    `\n• check for single quote (') like "Orion's Belt" or "Chargin' Targe"` +
+                    '\n• check for dot (.) like "Lucky No. 42" or "B.A.S.E. Jumper"' +
+                    '\n• check for exclamation mark (!) like "Bonk! Atomic Punch"' +
+                    `\n• if you're looking for uncraftable items, do it like "Non-Craftable Crit-a-Cola"`
             );
             return null;
         } else if (Array.isArray(match)) {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1627,14 +1627,16 @@ export = class Commands {
 
     private acceptCommand(steamID: SteamID, message: string): void {
         const offerIdAndMessage = CommandParser.removeCommand(message);
-        const offerId = new RegExp(/\d+/).exec(offerIdAndMessage).toString();
-
-        if (!offerId) {
-            this.bot.sendMessage(steamID, '⚠️ Missing offer id. Example: "!accepttrade 3957959294"');
+        const offerId = new RegExp(/\d+/).exec(offerIdAndMessage);
+        let offerIdString: string;
+        if (isNaN(+offerId) || !offerId) {
+            this.bot.sendMessage(steamID, '⚠️ Missing offer id. Example: "!accept 3957959294"');
             return;
+        } else {
+            offerIdString = offerId.toString();
         }
 
-        const state = this.bot.manager.pollData.received[offerId];
+        const state = this.bot.manager.pollData.received[offerIdString];
 
         if (state === undefined) {
             this.bot.sendMessage(steamID, '❌ Offer does not exist.');
@@ -1647,14 +1649,14 @@ export = class Commands {
             return;
         }
 
-        const offerData = this.bot.manager.pollData.offerData[offerId];
+        const offerData = this.bot.manager.pollData.offerData[offerIdString];
 
         if (offerData?.action.action !== 'skip') {
             this.bot.sendMessage(steamID, "❌ Offer can't be reviewed.");
             return;
         }
 
-        this.bot.trades.getOffer(offerId).asCallback((err, offer) => {
+        this.bot.trades.getOffer(offerIdString).asCallback((err, offer) => {
             if (err) {
                 this.bot.sendMessage(
                     steamID,
@@ -1665,7 +1667,7 @@ export = class Commands {
 
             this.bot.sendMessage(steamID, 'Accepting offer...');
 
-            const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerId].partner);
+            const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerIdString].partner);
             const reply = offerIdAndMessage.substr(offerId.length);
             const adminDetails = this.bot.friends.getFriend(steamID);
 
@@ -1690,14 +1692,16 @@ export = class Commands {
 
     private declineCommand(steamID: SteamID, message: string): void {
         const offerIdAndMessage = CommandParser.removeCommand(message);
-        const offerId = new RegExp(/\d+/).exec(offerIdAndMessage).toString();
-
-        if (!offerId) {
-            this.bot.sendMessage(steamID, '⚠️ Missing offer id. Example: "!declinetrade 3957959294"');
+        const offerId = new RegExp(/\d+/).exec(offerIdAndMessage);
+        let offerIdString: string;
+        if (isNaN(+offerId) || !offerId) {
+            this.bot.sendMessage(steamID, '⚠️ Missing offer id. Example: "!decline 3957959294"');
             return;
+        } else {
+            offerIdString = offerId.toString();
         }
 
-        const state = this.bot.manager.pollData.received[offerId];
+        const state = this.bot.manager.pollData.received[offerIdString];
 
         if (state === undefined) {
             this.bot.sendMessage(steamID, '❌ Offer does not exist.');
@@ -1710,14 +1714,14 @@ export = class Commands {
             return;
         }
 
-        const offerData = this.bot.manager.pollData.offerData[offerId];
+        const offerData = this.bot.manager.pollData.offerData[offerIdString];
 
         if (offerData?.action.action !== 'skip') {
             this.bot.sendMessage(steamID, "❌ Offer can't be reviewed.");
             return;
         }
 
-        this.bot.trades.getOffer(offerId).asCallback((err, offer) => {
+        this.bot.trades.getOffer(offerIdString).asCallback((err, offer) => {
             if (err) {
                 this.bot.sendMessage(
                     steamID,
@@ -1728,8 +1732,8 @@ export = class Commands {
 
             this.bot.sendMessage(steamID, 'Declining offer...');
 
-            const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerId].partner);
-            const reply = offerIdAndMessage.substr(offerId.length);
+            const partnerId = new SteamID(this.bot.manager.pollData.offerData[offerIdString].partner);
+            const reply = offerIdAndMessage.substr(offerIdString.length);
             const adminDetails = this.bot.friends.getFriend(steamID);
 
             this.bot.trades.applyActionToOffer('decline', 'MANUAL', {}, offer).asCallback(err => {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1584,6 +1584,7 @@ export = class Commands {
             offerData.action.meta.uniqueReasons.join(', ') +
             '). Summary:\n';
 
+        const keyPrice = this.bot.pricelist.getKeyPrices();
         const value: { our: Currency; their: Currency } = offerData.value;
 
         const items: {
@@ -1598,7 +1599,9 @@ export = class Commands {
                 '\nOffered: ' +
                 summarizeItems(items.their, this.bot.schema);
         } else {
-            const valueDiff = new Currencies(value.their).toValue() - new Currencies(value.our).toValue();
+            const valueDiff =
+                new Currencies(value.their).toValue(keyPrice.sell.metal) -
+                new Currencies(value.our).toValue(keyPrice.sell.metal);
             const valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
             reply +=
                 'Asked: ' +

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1450,9 +1450,10 @@ export = class Commands {
 
         const pollData = this.bot.manager.pollData;
         const oldestId = pollData.offerData === undefined ? undefined : Object.keys(pollData.offerData)[0];
-        const timeSince = process.env.TRADING_STARTING_TIME_UNIX
-            ? +process.env.TRADING_STARTING_TIME_UNIX
-            : pollData.timestamps[oldestId];
+        const timeSince =
+            +process.env.TRADING_STARTING_TIME_UNIX === 0
+                ? pollData.timestamps[oldestId]
+                : +process.env.TRADING_STARTING_TIME_UNIX;
         const totalDays = !timeSince ? 0 : now.diff(moment.unix(timeSince), 'days');
 
         const offerData = this.bot.manager.pollData.offerData;

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -927,7 +927,10 @@ export = class MyHandler extends Handler {
                 'Your offer is waiting for review, reason: ' +
                     meta.uniqueReasons.join(', ') +
                     '\n\nYour offer summary:\n' +
-                    offer.summarize(this.bot.schema) +
+                    offer
+                        .summarize(this.bot.schema)
+                        .replace('Asked', 'My side')
+                        .replace('Offered', 'Your side') +
                     (meta.uniqueReasons.includes('INVALID_VALUE') ? "\n(You're missing: " + valueDiffKey + ')' : '') +
                     (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
                         ? '\n\nNote:\n' + reviewReasons.join('\n')

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -906,7 +906,7 @@ export = class MyHandler extends Handler {
                     : 'INVALID_VALUE - Your offer will be ignored. Please cancel it and make another offer with correct value.';
                 reviewReasons.push(note);
                 missingPureNote =
-                    "\n[You're missing: " + itemsList.includes('5021;6') ? valueDiffKey : valueDiffRef + ' ref';
+                    "\n[You're missing: " + (itemsList.includes('5021;6') ? valueDiffKey : valueDiffRef + ' ref');
             }
             if (meta.uniqueReasons.includes('INVALID_ITEMS')) {
                 note = process.env.INVALID_ITEMS_NOTE

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -866,6 +866,7 @@ export = class MyHandler extends Handler {
             return;
         }
         const keyPrice = this.bot.pricelist.getKeyPrices();
+        const pureStock = this.pureStock();
         const items: { our: {}; their: {} } = offer.data('dict');
         const value: { our: Currency; their: Currency } = offer.data('value');
 
@@ -948,7 +949,13 @@ export = class MyHandler extends Handler {
                     (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
                         ? '\n\nNote:\n' + reviewReasons.join('\n')
                         : '') +
-                    (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '')
+                    (process.env.ADDITIONAL_NOTE
+                        ? '\n' +
+                          process.env.ADDITIONAL_NOTE.replace(
+                              /%keyRate%/g,
+                              keyPrice.sell.metal.toString() + ' ref'
+                          ).replace(/%pureStock%/g, pureStock.join(', ').toString())
+                        : '')
             );
             if (
                 process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -776,15 +776,21 @@ export = class MyHandler extends Handler {
                 const value: { our: Currency; their: Currency } = offer.data('value');
 
                 let valueDiff: number;
-                let valueDiffRef: string;
+                let valueDiffRef: number;
+                let valueDiffKey: string;
                 if (!value) {
                     valueDiff = 0;
-                    valueDiffRef = '';
+                    valueDiffRef = 0;
+                    valueDiffKey = '';
                 } else {
                     valueDiff =
                         new Currencies(value.their).toValue(keyPrice.sell.metal) -
                         new Currencies(value.our).toValue(keyPrice.sell.metal);
-                    valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
+                    valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9))));
+                    valueDiffKey = Currencies.toCurrencies(
+                        Math.abs(valueDiff),
+                        Math.abs(valueDiff) >= keyPrice.sell.metal ? keyPrice.sell.metal : undefined
+                    ).toString();
                 }
 
                 if (
@@ -802,11 +808,17 @@ export = class MyHandler extends Handler {
                             ' is accepted. Summary:\n' +
                             offer.summarize(this.bot.schema) +
                             (valueDiff > 0
-                                ? ')\n📈Profit from overpay: ' + valueDiffRef + ' ref'
+                                ? '\n📈Profit from overpay: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? ')\n📉Loss from underpay: ' + valueDiffRef + ' ref'
+                                ? '\n📉Loss from underpay: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : '') +
-                            '\nKey rate: ' +
+                            '\n🔑Key rate: ' +
                             keyPrice.buy.metal.toString() +
                             '/' +
                             keyPrice.sell.metal.toString() +
@@ -855,15 +867,21 @@ export = class MyHandler extends Handler {
         const value: { our: Currency; their: Currency } = offer.data('value');
 
         let valueDiff: number;
-        let valueDiffRef: string;
+        let valueDiffRef: number;
+        let valueDiffKey: string;
         if (!value) {
             valueDiff = 0;
-            valueDiffRef = '';
+            valueDiffRef = 0;
+            valueDiffKey = '';
         } else {
             valueDiff =
                 new Currencies(value.their).toValue(keyPrice.sell.metal) -
                 new Currencies(value.our).toValue(keyPrice.sell.metal);
-            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
+            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9))));
+            valueDiffKey = Currencies.toCurrencies(
+                Math.abs(valueDiff),
+                Math.abs(valueDiff) >= keyPrice.sell.metal ? keyPrice.sell.metal : undefined
+            ).toString();
         }
 
         if (!notify) {
@@ -910,7 +928,12 @@ export = class MyHandler extends Handler {
                     meta.uniqueReasons.join(', ') +
                     '\n\nYour offer summary:\n' +
                     offer.summarize(this.bot.schema) +
-                    (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false' ? '\nNote:\n' + reviewReasons.join('\n') : '') +
+                    '\n🔑Key rate: ' +
+                    keyPrice.sell.metal.toString() +
+                    ' ref/key' +
+                    (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
+                        ? '\n\nNote:\n' + reviewReasons.join('\n')
+                        : '') +
                     (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '')
             );
             if (
@@ -929,11 +952,17 @@ export = class MyHandler extends Handler {
                         '\nOffer Summary:\n' +
                         offer.summarize(this.bot.schema) +
                         (valueDiff > 0
-                            ? ')\n📈Profit from overpay: ' + valueDiffRef + ' ref'
+                            ? '\n📈Profit from overpay: ' +
+                              valueDiffRef +
+                              ' ref' +
+                              (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                             : valueDiff < 0
-                            ? ')\n📉Loss from underpay: ' + valueDiffRef + ' ref'
+                            ? '\n📉Loss from underpay: ' +
+                              valueDiffRef +
+                              ' ref' +
+                              (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                             : '') +
-                        '\nKey rate: ' +
+                        '\n🔑Key rate: ' +
                         keyPrice.buy.metal.toString() +
                         '/' +
                         keyPrice.sell.metal.toString() +
@@ -1176,15 +1205,21 @@ export = class MyHandler extends Handler {
         const value: { our: Currency; their: Currency } = offer.data('value');
 
         let valueDiff: number;
-        let valueDiffRef: string;
+        let valueDiffRef: number;
+        let valueDiffKey: string;
         if (!value) {
             valueDiff = 0;
-            valueDiffRef = '';
+            valueDiffRef = 0;
+            valueDiffKey = '';
         } else {
             valueDiff =
                 new Currencies(value.their).toValue(keyPrice.sell.metal) -
                 new Currencies(value.our).toValue(keyPrice.sell.metal);
-            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
+            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9))));
+            valueDiffKey = Currencies.toCurrencies(
+                Math.abs(valueDiff),
+                Math.abs(valueDiff) >= keyPrice.sell.metal ? keyPrice.sell.metal : undefined
+            ).toString();
         }
 
         let partnerAvatar: string;
@@ -1235,11 +1270,17 @@ export = class MyHandler extends Handler {
                             '\n\n__Offer Summary__:\n' +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (valueDiff > 0
-                                ? ')\n📈***Profit from overpay***: ' + valueDiffRef + ' ref'
+                                ? '\n📈***Profit from overpay***: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? ')\n📉***Loss from underpay***: ' + valueDiffRef + ' ref'
+                                ? '\n📉***Loss from underpay***: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : '') +
-                            '\nKey rate: ' +
+                            '\n🔑Key rate: ' +
                             keyPrice.buy.metal.toString() +
                             '/' +
                             keyPrice.sell.metal.toString() +
@@ -1271,15 +1312,21 @@ export = class MyHandler extends Handler {
         const value: { our: Currency; their: Currency } = offer.data('value');
 
         let valueDiff: number;
-        let valueDiffRef: string;
+        let valueDiffRef: number;
+        let valueDiffKey: string;
         if (!value) {
             valueDiff = 0;
-            valueDiffRef = '';
+            valueDiffRef = 0;
+            valueDiffKey = '';
         } else {
             valueDiff =
                 new Currencies(value.their).toValue(keyPrice.sell.metal) -
                 new Currencies(value.our).toValue(keyPrice.sell.metal);
-            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
+            valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9))));
+            valueDiffKey = Currencies.toCurrencies(
+                Math.abs(valueDiff),
+                Math.abs(valueDiff) >= keyPrice.sell.metal ? keyPrice.sell.metal : undefined
+            ).toString();
         }
 
         let tradesTotal = 0;
@@ -1344,11 +1391,17 @@ export = class MyHandler extends Handler {
                             'has been marked as accepted.\n__Summary__:\n' +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (valueDiff > 0
-                                ? ')\n📈***Profit from overpay***: ' + valueDiffRef + ' ref'
+                                ? '\n📈***Profit from overpay***: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? ')\n📉***Loss from underpay***: ' + valueDiffRef + ' ref'
+                                ? '\n📉***Loss from underpay***: ' +
+                                  valueDiffRef +
+                                  ' ref' +
+                                  (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : '') +
-                            '\nKey rate: ' +
+                            '\n🔑Key rate: ' +
                             keyPrice.buy.metal.toString() +
                             '/' +
                             keyPrice.sell.metal.toString() +

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -891,11 +891,18 @@ export = class MyHandler extends Handler {
         if (action === 'skip') {
             const reviewReasons: string[] = [];
             let note: string;
+            const missingPure: string[] = [];
+            let notePure: string;
             if (meta.uniqueReasons.includes('INVALID_VALUE')) {
                 note = process.env.INVALID_VALUE_NOTE
                     ? 'INVALID_VALUE - ' + process.env.INVALID_VALUE_NOTE
                     : 'INVALID_VALUE - Your offer will be ignored. Please cancel it and make another offer with correct value.';
                 reviewReasons.push(note);
+                notePure =
+                    "\n[You're missing: " +
+                    valueDiffRef +
+                    (valueDiffRef >= keyPrice.sell.metal ? ' ref (' + valueDiffKey + ')]' : ' ref]');
+                missingPure.push(notePure);
             }
             if (meta.uniqueReasons.includes('INVALID_ITEMS')) {
                 note = process.env.INVALID_ITEMS_NOTE
@@ -931,7 +938,9 @@ export = class MyHandler extends Handler {
                         .summarize(this.bot.schema)
                         .replace('Asked', 'My side')
                         .replace('Offered', 'Your side') +
-                    (meta.uniqueReasons.includes('INVALID_VALUE') ? "\n(You're missing: " + valueDiffKey + ')' : '') +
+                    (meta.uniqueReasons.includes('INVALID_VALUE') && !meta.uniqueReasons.includes('INVALID_ITEMS')
+                        ? missingPure
+                        : '') +
                     (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
                         ? '\n\nNote:\n' + reviewReasons.join('\n')
                         : '') +

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -805,15 +805,15 @@ export = class MyHandler extends Handler {
                             offer.id +
                             ' with ' +
                             offer.partner.getSteamID64() +
-                            ' is accepted. Summary:\n' +
+                            ' is accepted. ✅\n\nSummary:\n' +
                             offer.summarize(this.bot.schema) +
                             (valueDiff > 0
-                                ? '\n📈Profit from overpay: ' +
+                                ? '\n\n📈Profit from overpay: ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? '\n📉Loss from underpay: ' +
+                                ? '\n\n📉Loss from underpay: ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
@@ -822,7 +822,7 @@ export = class MyHandler extends Handler {
                             keyPrice.buy.metal.toString() +
                             '/' +
                             keyPrice.sell.metal.toString() +
-                            ' ref | Pure stock: ' +
+                            ' ref | 💰Pure stock: ' +
                             pureStock.join(', ').toString() +
                             ' ref',
                         []
@@ -935,7 +935,7 @@ export = class MyHandler extends Handler {
             // Notify partner and admin that the offer is waiting for manual review
             this.bot.sendMessage(
                 offer.partner,
-                'Your offer is waiting for review, reason: ' +
+                '⚠ Your offer is waiting for review, reason: ' +
                     meta.uniqueReasons.join(', ') +
                     '\n\nYour offer summary:\n' +
                     offer
@@ -948,10 +948,7 @@ export = class MyHandler extends Handler {
                     (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
                         ? '\n\nNote:\n' + reviewReasons.join('\n')
                         : '') +
-                    (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '') +
-                    '\n🔑Key rate: ' +
-                    keyPrice.sell.metal.toString() +
-                    ' ref/key'
+                    (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '')
             );
             if (
                 process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&
@@ -960,21 +957,21 @@ export = class MyHandler extends Handler {
                 this.sendWebHookReviewOfferSummary(offer, meta.uniqueReasons.join(', '));
             } else {
                 this.bot.messageAdmins(
-                    'Offer #' +
+                    '⚠ Offer #' +
                         offer.id +
                         ' from ' +
                         offer.partner +
                         ' is waiting for review, reason: ' +
                         meta.uniqueReasons.join(', ') +
-                        '\nOffer Summary:\n' +
+                        '\n\nOffer Summary:\n' +
                         offer.summarize(this.bot.schema) +
                         (valueDiff > 0
-                            ? '\n📈Profit from overpay: ' +
+                            ? '\n\n📈Profit from overpay: ' +
                               valueDiffRef +
                               ' ref' +
                               (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                             : valueDiff < 0
-                            ? '\n📉Loss from underpay: ' +
+                            ? '\n\n📉Loss from underpay: ' +
                               valueDiffRef +
                               ' ref' +
                               (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
@@ -1287,12 +1284,12 @@ export = class MyHandler extends Handler {
                             '\n\n__Offer Summary__:\n' +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (valueDiff > 0
-                                ? '\n📈***Profit from overpay***: ' +
+                                ? '\n📈***Profit from overpay:*** ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? '\n📉***Loss from underpay***: ' +
+                                ? '\n📉***Loss from underpay:*** ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
@@ -1408,12 +1405,12 @@ export = class MyHandler extends Handler {
                             'has been marked as accepted.\n__Summary__:\n' +
                             tradeSummary.replace('Asked:', '**Asked:**').replace('Offered:', '**Offered:**') +
                             (valueDiff > 0
-                                ? '\n📈***Profit from overpay***: ' +
+                                ? '\n📈***Profit from overpay:*** ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
                                 : valueDiff < 0
-                                ? '\n📉***Loss from underpay***: ' +
+                                ? '\n📉***Loss from underpay:*** ' +
                                   valueDiffRef +
                                   ' ref' +
                                   (valueDiffRef >= keyPrice.sell.metal ? ' (' + valueDiffKey + ')' : '')
@@ -1422,7 +1419,7 @@ export = class MyHandler extends Handler {
                             keyPrice.buy.metal.toString() +
                             '/' +
                             keyPrice.sell.metal.toString() +
-                            ' ref | Pure stock: ' +
+                            ' ref | 💰Pure stock: ' +
                             pureStock.join(', ').toString() +
                             ' ref\n' +
                             (process.env.DISCORD_WEBHOOK_TRADE_SUMMARY_ADDITIONAL_DESCRIPTION_NOTE

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -912,13 +912,13 @@ export = class MyHandler extends Handler {
             if (meta.uniqueReasons.includes('DUPE_ITEMS')) {
                 note = process.env.DUPE_ITEMS_NOTE
                     ? 'DUPE_ITEMS - ' + process.env.DUPE_ITEMS_NOTE
-                    : 'DUPE_ITEMS - The item you offered is appeared to be duped. Please wait for my owner to review it. Thank you.';
+                    : 'DUPE_ITEMS - The item(s) you offered is appeared to be duped. Please wait for my owner to review it. Thank you.';
                 reviewReasons.push(note);
             }
             if (meta.uniqueReasons.includes('DUPE_CHECK_FAILED')) {
                 note = process.env.DUPE_CHECK_FAILED_NOTE
                     ? 'DUPE_CHECK_FAILED - ' + process.env.DUPE_CHECK_FAILED_NOTE
-                    : 'DUPE_CHECK_FAILED - Backpack.tf still does not recognized your item Original ID to check for duped item. You can try again later. Check it yourself by go to your item history page. Thank you.';
+                    : 'DUPE_CHECK_FAILED - Backpack.tf still does not recognize your item(s) Original ID to check for the duped item. You can try again later. Check it yourself by going to your item history page. Thank you.';
                 reviewReasons.push(note);
             }
             // Notify partner and admin that the offer is waiting for manual review
@@ -928,13 +928,14 @@ export = class MyHandler extends Handler {
                     meta.uniqueReasons.join(', ') +
                     '\n\nYour offer summary:\n' +
                     offer.summarize(this.bot.schema) +
-                    '\n🔑Key rate: ' +
-                    keyPrice.sell.metal.toString() +
-                    ' ref/key' +
+                    (meta.uniqueReasons.includes('INVALID_VALUE') ? "\n(You're missing: " + valueDiffKey + ')' : '') +
                     (process.env.DISABLE_REVIEW_OFFER_NOTE === 'false'
                         ? '\n\nNote:\n' + reviewReasons.join('\n')
                         : '') +
-                    (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '')
+                    (process.env.ADDITIONAL_NOTE ? '\n' + process.env.ADDITIONAL_NOTE : '') +
+                    '\n🔑Key rate: ' +
+                    keyPrice.sell.metal.toString() +
+                    ' ref/key'
             );
             if (
                 process.env.DISABLE_DISCORD_WEBHOOK_OFFER_REVIEW === 'false' &&

--- a/src/lib/extend/offer/summarize.ts
+++ b/src/lib/extend/offer/summarize.ts
@@ -9,6 +9,7 @@ import SKU from 'tf2-sku';
 export = function(schema: SchemaManager.Schema): string {
     // @ts-ignore
     const self = this as TradeOffer;
+    // @ts-ignore
 
     const value: { our: Currency; their: Currency } = self.data('value');
 
@@ -20,8 +21,6 @@ export = function(schema: SchemaManager.Schema): string {
     if (!value) {
         return 'Asked: ' + summarizeItems(items.our, schema) + '\nOffered: ' + summarizeItems(items.their, schema);
     } else {
-        const valueDiff = new Currencies(value.their).toValue() - new Currencies(value.our).toValue();
-        const valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
         return (
             'Asked: ' +
             new Currencies(value.our).toString() +
@@ -31,11 +30,7 @@ export = function(schema: SchemaManager.Schema): string {
             new Currencies(value.their).toString() +
             ' (' +
             summarizeItems(items.their, schema) +
-            (valueDiff > 0
-                ? ')\nProfit from overpay: ' + valueDiffRef + ' ref'
-                : valueDiff < 0
-                ? ')\nLoss from underpay: ' + valueDiffRef + ' ref'
-                : ')')
+            ')'
         );
     }
 };

--- a/src/lib/extend/offer/summarizeWithLink.ts
+++ b/src/lib/extend/offer/summarizeWithLink.ts
@@ -25,8 +25,6 @@ export = function(schema: SchemaManager.Schema): string {
             summarizeItemsWithLink(items.their, schema)
         );
     } else {
-        const valueDiff = new Currencies(value.their).toValue() - new Currencies(value.our).toValue();
-        const valueDiffRef = Currencies.toRefined(Currencies.toScrap(Math.abs(valueDiff * (1 / 9)))).toString();
         return (
             'Asked: ' +
             new Currencies(value.our).toString() +
@@ -36,11 +34,7 @@ export = function(schema: SchemaManager.Schema): string {
             new Currencies(value.their).toString() +
             ' (' +
             summarizeItemsWithLink(items.their, schema) +
-            (valueDiff > 0
-                ? ')\nProfit from overpay: ' + valueDiffRef + ' ref'
-                : valueDiff < 0
-                ? ')\nLoss from underpay: ' + valueDiffRef + ' ref'
-                : ')')
+            ')'
         );
     }
 };


### PR DESCRIPTION
**fixes**
- fix bot crash if `ENABLE_SHOW_ONLY_METAL` option is set to `false` in ecosystem.json/.env
- fix !stats command always saying '0 days ago' if you value in ecosystem,json/.env is 0
- fix bot crash when sending non-numbers on "!accept <offerID>" or "!decline<offerID>" commands

**Offer review changes:**
- add how many trade partner is missing for INVALID_VALUE trades (does not appear if include INVALID_ITEMS trades)
- change "Asked/Offered" to "My/Your side" on the message that the trade partner will receive
- option to show keyRate and pureStock - You'll need to add `%keyRate%` or `%pureStock%` in the `ADDITIONAL_NOTE` variable in your ecosystem.json/.env if you want to use it. The outputs:
`%keyRate%`: **x ref** 
%pureStock%: **Key: x, Ref: y**

**Others**
- add some useful trade for trade partner (cart and if the item not found)
- change something so that non-Discord Webhook users can see some clear texts.